### PR TITLE
Update README.md for PING credential-considerations

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Earlier proposals still being discussed:
 * [navigator.identity.get()](navigator-identity-proposal.md)
 * [Mobile Document Request API](mobile-document-request-api-proposal.md)
 
+Risks and mitigation principals for the larger online real-world-identity space are being worked on as part of the W3C PING's [credential-considerations repository](https://github.com/w3cping/credential-considerations).
+
 ## Alternatives being developed elsewhere
 
 * Analysis of [custom URL schemes](custom-schemes.md)


### PR DESCRIPTION
Hey @marcoscaceres,
Talking with Nick, I'm [moving](https://github.com/w3cping/credential-considerations/pull/3) my risks discussion into the PING repo he created. I figured we can just reference that repo from ours for now, sound good?